### PR TITLE
Handle errors in a better way

### DIFF
--- a/lib/methodes/equipement.js
+++ b/lib/methodes/equipement.js
@@ -20,6 +20,7 @@ let getCategories = async function() {
         let data = JSON.parse(body);
         if (data.status == 'success')
         return resolve(data.data);
+        error = data.message;
       }
       return reject(error);
     });
@@ -33,12 +34,13 @@ let getEquipements = async function(parameters) {
       url: `https://api.paris.fr/api/data/1.1/Equipements/get_equipements/?token=${token}`,
       form: parameters
     }, function (error, response, body) {
-      let data = JSON.parse(body);
       if (!error && response.statusCode == 200) {
+        let data = JSON.parse(body);
         if (data.status == 'success')
         return resolve(data.data);
+        error = data.message;
       }
-      return reject(data.message);
+      return reject(error);
     });
   })
 }
@@ -50,12 +52,13 @@ let getEquipement = async function(parameters) {
       url: `https://api.paris.fr/api/data/1.0/Equipements/get_equipement/?token=${token}`,
       form: parameters
     }, function (error, response, body) {
-      let data = JSON.parse(body);
       if (!error && response.statusCode == 200) {
+        let data = JSON.parse(body);
         if (data.status == 'success')
         return resolve(data.data);
+        error = data.message;
       }
-      return reject(data.message);
+      return reject(error);
     });
   })
 }
@@ -67,12 +70,13 @@ let getGeoEquipements = async function(parameters) {
       url: `https://api.paris.fr/api/data/1.1/Equipements/get_geo_equipements/?token=${token}`,
       form: parameters
     }, function (error, response, body) {
-      let data = JSON.parse(body);
       if (!error && response.statusCode == 200) {
+        let data = JSON.parse(body);
         if (data.status == 'success')
         return resolve(data.data);
+        error = data.message;
       }
-      return reject(data.message);
+      return reject(error);
     });
   })
 }
@@ -84,12 +88,13 @@ let getCrowdLevel = async function(parameters) {
       url: `https://api.paris.fr/api/data/1.0/Equipements/get_crowd_level/?token=${token}`,
       form: parameters
     }, function (error, response, body) {
-      let data = JSON.parse(body);
       if (!error && response.statusCode == 200) {
+        let data = JSON.parse(body);
         if (data.status == 'success')
         return resolve(data.data);
+        error = data.message;
       }
-      return reject(data.message);
+      return reject(error);
     });
   })
 }

--- a/lib/methodes/quefaire.js
+++ b/lib/methodes/quefaire.js
@@ -24,12 +24,13 @@ let getCategories = async function() {
     request({
       url: `https://api.paris.fr/api/data/2.1/QueFaire/get_categories/?token=${token}`
     }, function (error, response, body) {
-      let data = JSON.parse(body);
       if (!error && response.statusCode == 200) {
+        let data = JSON.parse(body);
         if (data.status == 'success')
         return resolve(data.data);
+        error = data.message;
       }
-      return reject(data.message);
+      return reject(error);
     });
   })
 }
@@ -40,12 +41,13 @@ let getUnivers = async function() {
     request({
       url: `https://api.paris.fr/api/data/2.0/QueFaire/get_univers/?token=${token}`
     }, function (error, response, body) {
-      let data = JSON.parse(body);
       if (!error && response.statusCode == 200) {
+        let data = JSON.parse(body);
         if (data.status == 'success')
         return resolve(data.data);
+        error = data.message;
       }
-      return reject(data.message);
+      return reject(error);
     });
   })
 }
@@ -56,12 +58,13 @@ let getDisciplines = async function() {
     request({
       url: `https://api.paris.fr/api/data/2.1/QueFaire/get_disciplines/?token=${token}`
     }, function (error, response, body) {
-      let data = JSON.parse(body);
       if (!error && response.statusCode == 200) {
+        let data = JSON.parse(body);
         if (data.status == 'success')
         return resolve(data.data);
+        error = data.message;
       }
-      return reject(data.message);
+      return reject(error);
     });
   })
 }
@@ -72,12 +75,13 @@ let getTags = async function() {
     request({
       url: `https://api.paris.fr/api/data/2.1/QueFaire/get_tags/?token=${token}`
     }, function (error, response, body) {
-      let data = JSON.parse(body);
       if (!error && response.statusCode == 200) {
+        let data = JSON.parse(body);
         if (data.status == 'success')
         return resolve(data.data);
+        error = data.message;
       }
-      return reject(data.message);
+      return reject(error);
     });
   })
 }
@@ -89,13 +93,13 @@ let getEvents = async function(parameters) {
       url: `https://api.paris.fr/api/data/2.2/QueFaire/get_events/?token=${token}`,
       form: parameters
     }, function (error, response, body) {
-      form: parameters
-      let data = JSON.parse(body);
       if (!error && response.statusCode == 200) {
+        let data = JSON.parse(body);
         if (data.status == 'success')
         return resolve(data.data);
+        error = data.message;
       }
-      return reject(data.message);
+      return reject(error);
     });
   })
 }
@@ -107,13 +111,13 @@ let getActivities = async function(parameters) {
       url: `https://api.paris.fr/api/data/2.1/QueFaire/get_activities/?token=${token}`,
       form: parameters
     }, function (error, response, body) {
-      form: parameters
-      let data = JSON.parse(body);
       if (!error && response.statusCode == 200) {
+        let data = JSON.parse(body);
         if (data.status == 'success')
         return resolve(data.data);
+        error = data.message;
       }
-      return reject(data.message);
+      return reject(error);
     });
   })
 }
@@ -125,13 +129,13 @@ let getActivity = async function(parameters) {
       url: `https://api.paris.fr/api/data/2.0/QueFaire/get_activity/?token=${token}`,
       form: parameters
     }, function (error, response, body) {
-      form: parameters
-      let data = JSON.parse(body);
       if (!error && response.statusCode == 200) {
+        let data = JSON.parse(body);
         if (data.status == 'success')
         return resolve(data.data);
+        error = data.message;
       }
-      return reject(data.message);
+      return reject(error);
     });
   })
 }
@@ -143,13 +147,13 @@ let searchActivities = async function(parameters) {
       url: `https://api.paris.fr/api/data/2.0/QueFaire/search_activities/?token=${token}`,
       form: parameters
     }, function (error, response, body) {
-      form: parameters
-      let data = JSON.parse(body);
       if (!error && response.statusCode == 200) {
+        let data = JSON.parse(body);
         if (data.status == 'success')
         return resolve(data.data);
+        error = data.message;
       }
-      return reject(data.message);
+      return reject(error);
     });
   })
 }
@@ -161,13 +165,13 @@ let getProgramme = async function(parameters) {
       url: `https://api.paris.fr/api/data/1.5/QueFaire/get_programme/?token=${token}`,
       form: parameters
     }, function (error, response, body) {
-      form: parameters
-      let data = JSON.parse(body);
       if (!error && response.statusCode == 200) {
+        let data = JSON.parse(body);
         if (data.status == 'success')
         return resolve(data.data);
+        error = data.message;
       }
-      return reject(data.message);
+      return reject(error);
     });
   })
 }
@@ -179,13 +183,13 @@ let getRecords = async function(parameters) {
       url: `https://api.paris.fr/api/data/2.1/QueFaire/get_records/?token=${token}`,
       form: parameters
     }, function (error, response, body) {
-      form: parameters
-      let data = JSON.parse(body);
       if (!error && response.statusCode == 200) {
+        let data = JSON.parse(body);
         if (data.status == 'success')
         return resolve(data.data);
+        error = data.message;
       }
-      return reject(data.message);
+      return reject(error);
     });
   })
 }
@@ -197,13 +201,13 @@ let getGeoActivities = async function(parameters) {
       url: `https://api.paris.fr/api/data/1.4/QueFaire/get_geo_activities/?token=${token}`,
       form: parameters
     }, function (error, response, body) {
-      form: parameters
-      let data = JSON.parse(body);
       if (!error && response.statusCode == 200) {
+        let data = JSON.parse(body);
         if (data.status == 'success')
         return resolve(data.data);
+        error = data.message;
       }
-      return reject(data.message);
+      return reject(error);
     });
   })
 }


### PR DESCRIPTION
On some cases, the request fails. And, as a failure, `body` equals to `null` and cannot be parsed as a json. 

```diff
     }, function (error, response, body) {
-      let data = JSON.parse(body);
       if (!error && response.statusCode == 200) {
+        let data = JSON.parse(body);
         if (data.status == 'success')
         return resolve(data.data);
+        error = data.message;
       }
-      return reject(data.message);
+      return reject(error);
     });
```